### PR TITLE
chore: use literal union type instead of enums

### DIFF
--- a/src/TreeToTS/templates/resolveValueTypes.ts
+++ b/src/TreeToTS/templates/resolveValueTypes.ts
@@ -2,6 +2,7 @@ import { Options, ParserField } from '@/Models';
 import { Helpers, TypeDefinition, TypeSystemDefinition } from '@/Models/Spec';
 import { truthyType } from '@/TreeToTS/templates/truthy';
 import { customScalarsMap } from './customScalarsMap';
+import { toTypeNameFromEnum } from './utils';
 
 export const VALUETYPES = 'ValueTypes';
 
@@ -90,7 +91,7 @@ const resolveValueTypeFromRoot = (i: ParserField, rootNodes: ParserField[], enum
     )}`;
   }
   if (i.data.type === TypeDefinition.EnumTypeDefinition) {
-    return `${plusDescription(i.description)}["${i.name}"]:${i.name}`;
+    return `${plusDescription(i.description)}["${i.name}"]:${toTypeNameFromEnum(i.name)}`;
   }
   if (i.data.type === TypeDefinition.InputObjectTypeDefinition) {
     return `${plusDescription(i.description)}["${i.name}"]: {\n${i.args.map((f) => resolveArg(f)).join(',\n')}\n}`;

--- a/src/TreeToTS/templates/returnedTypes.ts
+++ b/src/TreeToTS/templates/returnedTypes.ts
@@ -1,6 +1,7 @@
 import { Options, ParserField } from '@/Models';
 import { Helpers, TypeDefinition, TypeSystemDefinition } from '@/Models/Spec';
 import { customScalarsMap } from './customScalarsMap';
+import { toTypeNameFromEnum } from './utils';
 
 export const TYPES = 'GraphQLTypes';
 
@@ -62,9 +63,9 @@ const resolveEnum = (i: ParserField): string => {
   if (!i.args) {
     throw new Error('Empty enum error');
   }
-  return `${plusDescription(i.description)}export enum ${i.name} {\n${i.args
-    .map((f) => `\t${f.name} = "${f.name}"`)
-    .join(',\n')}\n}`;
+  const typeName = toTypeNameFromEnum(i.name);
+  const stringLiterals = i.args.map((f) => `'${f.name}'`).join(' | ');
+  return `${plusDescription(i.description)}export type ${typeName} = ${stringLiterals}\n`;
 };
 
 export const resolveTypeFromRoot = (i: ParserField, rootNodes: ParserField[]): string => {
@@ -87,7 +88,7 @@ export const resolveTypeFromRoot = (i: ParserField, rootNodes: ParserField[]): s
 \t${i.args.map((f) => `['...on ${f.type.name}']: '__union' & ${TYPES}["${f.type.name}"];`).join('\n\t')}\n}`;
   }
   if (i.data.type === TypeDefinition.EnumTypeDefinition) {
-    return `${plusDescription(i.description)}["${i.name}"]: ${i.name}`;
+    return `${plusDescription(i.description)}["${i.name}"]: ${toTypeNameFromEnum(i.name)}`;
   }
   if (i.data.type === TypeDefinition.InputObjectTypeDefinition) {
     return `${plusDescription(i.description)}["${i.name}"]: {\n\t${i.args.map((f) => resolveField(f)).join(',\n')}\n}`;

--- a/src/TreeToTS/templates/utils.ts
+++ b/src/TreeToTS/templates/utils.ts
@@ -1,0 +1,6 @@
+export const toTypeNameFromEnum = (enumName: string) => {
+  return enumName
+    .split('_')
+    .map((part) => `${part[0].toUpperCase()}${part.slice(1).toLowerCase()}`)
+    .join('');
+};


### PR DESCRIPTION
In order to be able to generate two versions of the codegen:
- one for the backend generated from the "admin" permissions
- one for the frontend generated from the "org_owner" permissions

we need to replace enums by literals unions so that we can share some code between the 2 SDKs. Indeed, when using enums, Typescript complains about not having any overlap between enums even if they have the same values:
<img width="988" alt="image" src="https://user-images.githubusercontent.com/2678610/161303594-c9030409-a855-487e-94a8-dd6448a7a2c9.png"> ([code](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBMAdgVwLYJag+gZwJapgA2wcA3gLABQccAxgIY7ACMcAvHAOSPMtcAaarV7AATB26ixg6gF9qoSLAxpV2fIRJYJlGvSatJPQ-yH7px6bKoKq1OhEQ4IJAHREIAcwAUSNLgExMBuomzsEeqBWsA6AJRAA))


While string literals unions can simply be compared:
<img width="290" alt="image" src="https://user-images.githubusercontent.com/2678610/161303751-b0d9bc5f-7b7b-46db-b926-553a9faba1ad.png">


Another benefit of using string literals unions is that they are non generated to the build output.