### PR TITLE
fix: create a custom scalars map with some Hasura specific types

### DIFF
--- a/src/TreeToTS/templates/customScalarsMap.ts
+++ b/src/TreeToTS/templates/customScalarsMap.ts
@@ -1,7 +1,7 @@
 export const customScalarsMap: Record<string, string> = {
   uuid: 'string',
   timestamptz: 'string',
-  json: 'Record<string, any>',
-  jsonb: 'Record<string, any>',
+  json: 'any',
+  jsonb: 'any',
   numeric: 'number',
 };


### PR DESCRIPTION
It turns out that we can also use arrays in json/jsonb types. Therefore, typing them as `Record<string, any>` is wrong.