### PR TITLE
fix(typescript): stricter input and output typing

### DIFF
--- a/src/TreeToTS/templates/typescript/types.ts
+++ b/src/TreeToTS/templates/typescript/types.ts
@@ -51,7 +51,11 @@ type IsInterfaced<SRC extends DeepAnify<DST>, DST> = FlattenArray<SRC> extends Z
         >]: IsPayLoad<DST[P]> extends ${truthyType} ? SRC[P] : IsArray<SRC[P], DST[P]>;
       }
   : {
-      [P in keyof Pick<SRC, keyof DST>]: IsPayLoad<DST[P]> extends ${truthyType} ? SRC[P] : IsArray<SRC[P], DST[P]>;
+    [P in keyof Pick<SRC, keyof DST & keyof SRC>]: IsPayLoad<DST[P]> extends ${truthyType}
+      ? SRC[P]
+      : null extends SRC[P]
+      ? IsArray<SRC[P], DST[P]> | null
+      : IsArray<SRC[P], DST[P]>;
     };
 
 export type MapType<SRC, DST> = SRC extends DeepAnify<DST> ? IsInterfaced<SRC, DST> : never;

--- a/src/plugins/apollo/index.ts
+++ b/src/plugins/apollo/index.ts
@@ -8,7 +8,7 @@ const pluginApolloOps = ({ queryName, operation }: { queryName: string; operatio
     queryName,
     operation,
     ts: `export function useTyped${capitalized}<Z extends ValueTypes[O], O extends "${queryName}">(
-  ${operation}: Z | ValueTypes[O],
+  ${operation}:  (Z & ValueTypes[O]) | ValueTypes[O],
   options?: ${capitalized}HookOptions<InputType<GraphQLTypes[O], Z>>,
   operationName?: string,
 ) {


### PR DESCRIPTION
This fixes 2 major typing issues we had:
- prevent passing invalid property to selectors (like in `useTypedQuery()`)
- correctly mark nullable fields nullable (for example for `xxx_by_pk` or optional Hasura relations)