### PR TITLE
fix: even better type-safety

### DIFF
--- a/src/TreeToTS/functions/ZeusSelect.ts
+++ b/src/TreeToTS/functions/ZeusSelect.ts
@@ -1,5 +1,0 @@
-import { StringFunction } from './models';
-
-export const ZeusSelectFunction: StringFunction = {
-  ts: `export const ZeusSelect = <T>() => ((t: any) => t) as SelectionFunction<T>;`,
-};

--- a/src/TreeToTS/functions/index.ts
+++ b/src/TreeToTS/functions/index.ts
@@ -1,7 +1,6 @@
 export * from './buildQuery';
 export * from './ScalarResolver';
 export * from './TypesPropsResolver';
-export * from './ZeusSelect';
 export * from './fullChainConstruct';
 export * from './fullSubscriptionConstruct';
 export * from './inspectVariables';

--- a/src/TreeToTS/templates/typescript/functions.ts
+++ b/src/TreeToTS/templates/typescript/functions.ts
@@ -1,6 +1,5 @@
 import { Environment } from '@/Models';
 import {
-  ZeusSelectFunction,
   TypePropsResolverFunction,
   traverseToSeekArraysFunction,
   ScalarResolverFunction,
@@ -17,7 +16,6 @@ import {
 } from '@/TreeToTS/functions';
 
 export const typescriptFunctions = (env: Environment): string => `
-${ZeusSelectFunction.ts}
 ${ScalarResolverFunction.ts}
 ${TypePropsResolverFunction.ts}
 ${isArrayFunctionFunction.ts}

--- a/src/TreeToTS/templates/typescript/operations.ts
+++ b/src/TreeToTS/templates/typescript/operations.ts
@@ -31,7 +31,7 @@ export const Thunder = (fn: FetchFunction) => <
   R extends keyof ${VALUETYPES} = GenericOperation<O>
 >(
   operation: O,
-) => <Z extends ${VALUETYPES}[R]>(o: Z | ${VALUETYPES}[R], ops?: OperationOptions) =>
+) => <Z extends ${VALUETYPES}[R]>(o: Z & ${VALUETYPES}[R], ops?: OperationOptions) =>
   fullChainConstruct(fn)(operation, allOperations[operation])(o as any, ops) as Promise<InputType<${TYPES}[R], Z>>;
 
 export const Chain = (...options: chainOptions) => Thunder(apiFetch(options));  
@@ -42,7 +42,7 @@ export const SubscriptionThunder = (fn: SubscriptionFunction) => <
 >(
   operation: O,
 ) => <Z extends ${VALUETYPES}[R]>(
-  o: Z | ${VALUETYPES}[R],
+  o: Z & ${VALUETYPES}[R],
   ops?: OperationOptions
 )=>
   fullSubscriptionConstruct(fn)(operation, allOperations[operation])(
@@ -67,13 +67,16 @@ const generateOperationsZeusTypeScript = ({ query, mutation, subscription }: Par
   R extends keyof ValueTypes = GenericOperation<O>
 >(
   operation: O,
-  o: Z | ${VALUETYPES}[R],
+  o: Z & ${VALUETYPES}[R],
   operationName?: string,
 ) => queryConstruct(operation, allOperations[operation], operationName)(o as any);`;
 };
 
 const generateSelectorsZeusTypeScript = () => {
-  return `export const Selector = <T extends keyof ${VALUETYPES}>(key: T) => ZeusSelect<${VALUETYPES}[T]>();`;
+  return `export const Selector =
+  <T extends keyof ${VALUETYPES}>(key: T) =>
+  <Z extends ${VALUETYPES}[T]>(o: Z & ${VALUETYPES}[T]): Z =>
+    o;`;
 };
 
 export const bodyTypeScript = (env: Environment, resolvedOperations: ResolvedOperations): string => `

--- a/src/TreeToTS/templates/typescript/types.ts
+++ b/src/TreeToTS/templates/typescript/types.ts
@@ -79,7 +79,6 @@ export type SubscriptionToGraphQL<Z, T> = {
   error: (fn: (e: { data?: InputType<T, Z>; errors?: string[] }) => void) => void;
   open: () => void;
 };
-export type SelectionFunction<V> = <T>(t: T | V) => T;
 export type fetchOptions = ArgsType<typeof fetch>;
 type websocketOptions = typeof WebSocket extends new (
   ...args: infer R

--- a/src/plugins/apollo/index.ts
+++ b/src/plugins/apollo/index.ts
@@ -8,7 +8,7 @@ const pluginApolloOps = ({ queryName, operation }: { queryName: string; operatio
     queryName,
     operation,
     ts: `export function useTyped${capitalized}<Z extends ValueTypes[O], O extends "${queryName}">(
-  ${operation}:  (Z & ValueTypes[O]) | ValueTypes[O],
+  ${operation}:  Z & ValueTypes[O],
   options?: ${capitalized}HookOptions<InputType<GraphQLTypes[O], Z>>,
   operationName?: string,
 ) {


### PR DESCRIPTION
This improves the fixes made in #7. It does it in a simpler way and and all functions (Thunder and Selector included).